### PR TITLE
Remove workaround for legacy versions of wkhtmltopdf

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,0 @@
-SOURCE_URL=https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
-SOURCE_SUM=049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db
-SOURCE_FILE=wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
-SOURCE_FORMAT=tar.xz
-SOURCE_SUM_PRG=sha256sum

--- a/scripts/install
+++ b/scripts/install
@@ -152,20 +152,9 @@ fi
 #=================================================
 ynh_script_progression --message="Building app..." --weight=1
 
-if ! wkhtmltopdf --version | grep "wkhtmltopdf 0.12.4 (with patched qt)"; then
-	# The debian package has a bug so we deploy a more recent version
-	if [ -f '../manifest.json' ] ; then
-		ynh_setup_source /usr/
-	else
-		OLD_YNH_CWD=$YNH_CWD
-		YNH_CWD=$YNH_CWD/../settings/conf
-		ynh_setup_source /usr/
-		YNH_CWD=$OLD_YNH_CWD
-	fi
-fi
 pushd $final_path
 	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y'
-	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 
+	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin"
 	if grep "python3" $final_path/$appname/$FORKNAME-bin ; then
 		python3 -m venv venv
 		venv/bin/pip3 install --upgrade pip

--- a/scripts/restore
+++ b/scripts/restore
@@ -111,20 +111,9 @@ fi
 #=================================================
 ynh_script_progression --message="Building app..." --weight=1
 
-if ! wkhtmltopdf --version | grep "wkhtmltopdf 0.12.4 (with patched qt)"; then
-	# The debian package has a bug so we deploy a more recent version
-	if [ -f '../manifest.json' ] ; then
-		ynh_setup_source /usr/
-	else
-		OLD_YNH_CWD=$YNH_CWD
-		YNH_CWD=$YNH_CWD/../settings/conf
-		ynh_setup_source /usr/
-		YNH_CWD=$OLD_YNH_CWD
-	fi
-fi
 pushd $final_path
 	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y'
-	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 
+	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin"
 	if grep "python3" $final_path/$appname/$FORKNAME-bin ; then
 		python3 -m venv venv
 		venv/bin/pip3 install --upgrade pip

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -125,20 +125,9 @@ fi
 #=================================================
 ynh_script_progression --message="Building app..." --weight=1
 
-if ! wkhtmltopdf --version | grep "wkhtmltopdf 0.12.4 (with patched qt)"; then
-	# The debian package has a bug so we deploy a more recent version
-	if [ -f '../manifest.json' ] ; then
-		ynh_setup_source /usr/
-	else
-		OLD_YNH_CWD=$YNH_CWD
-		YNH_CWD=$YNH_CWD/../settings/conf
-		ynh_setup_source /usr/
-		YNH_CWD=$OLD_YNH_CWD
-	fi
-fi
 pushd $final_path
 	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y'
-	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 
+	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin"
 	if grep "python3" $final_path/$appname/$FORKNAME-bin ; then
 		python3 -m venv venv
 		venv/bin/pip3 install --upgrade pip
@@ -151,7 +140,7 @@ pushd $final_path
 		venv/bin/pip install -r $appname/requirements.txt
 	fi
 	ynh_secure_remove --file="$final_path/.cargo"
-	ynh_secure_remove --file="$final_path/.rustup"	
+	ynh_secure_remove --file="$final_path/.rustup"
 popd
 
 #=================================================


### PR DESCRIPTION
This is a fishy workaround, Debian already provides newer versions of wkhtmltopdf, so that should be fine.