### PR TITLE
[FIX] add /websocket configuration for v16+

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -23,6 +23,20 @@ location @__APP__ {
   proxy_send_timeout 720s;
 }
 
+location /websocket {
+  proxy_pass http://127.0.0.1:__PORT_CHAT__;
+  proxy_set_header	Host $host;
+  proxy_set_header	X-Real-IP $remote_addr;
+  proxy_set_header	X-Forwarded-Proto $scheme;
+  proxy_set_header	X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header	X-Forwarded-Host $host;
+  proxy_set_header	Upgrade $http_upgrade;
+  proxy_set_header	Connection $connection_upgrade;
+  proxy_read_timeout 720s;
+  proxy_connect_timeout 720s;
+  proxy_send_timeout 720s;
+}
+
 location /longpolling {
   proxy_pass http://127.0.0.1:__PORT_CHAT__;
   proxy_set_header	Host $host;


### PR DESCRIPTION
## Problem

- *chatter and other functionality relying on longpolling don't work in v16+*

## Solution

- *the below snippet adds the /websocket endpoint odoo needs for this functionality*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
